### PR TITLE
fix(packages): :bug: update valid new chapters to one day

### DIFF
--- a/packages/layer-prisma/src/model/chapter/chapter.model.ts
+++ b/packages/layer-prisma/src/model/chapter/chapter.model.ts
@@ -81,11 +81,15 @@ export class ChapterModel extends PrismaDB {
   public async cronFindLastChapterEnabledToPublish(novelId: string) {
     const prisma = await this.connect.public();
 
+    const yesterday = new Date();
+    yesterday.setHours(yesterday.getHours() - 24);
+    yesterday.setMinutes(yesterday.getMinutes() - 1);
+
     const lastChapter = await prisma.chapter.findFirst({
       where: {
         novelId,
         createdAt: {
-          gte: new Date(Date.now() - 1000 * 60 * 60), // 1 hour ago
+          gte: yesterday,
         },
       },
       orderBy: {


### PR DESCRIPTION
Old behavior:
- The function that search last chapters only search in the last hour from the execution of the cron-job.

New behavior:
- Now the function search in the last 23 hours and 59 minutes from the execution of the cron-job.